### PR TITLE
Update limit option defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Usage: python -m cli [OPTIONS] GROUP_URL
 Common options include:
 
 - `--output PATH` – where to write the resulting mbox file.
-- `--limit N` – maximum number of threads to fetch.
+- `--limit N` – maximum number of threads to fetch (omit to fetch all).
 - `--delay SECONDS` – polite delay between requests.
 - `--text-format {html,markdown,plaintext}` – format of message bodies.
 

--- a/cli.py
+++ b/cli.py
@@ -28,7 +28,13 @@ def make_full_url(base_url: str, thread_path: str) -> str:
 @click.command()
 @click.argument("group_url")
 @click.option("--output", "output_file", default="group_archive.mbox", type=click.Path(), help="Output mbox file path")
-@click.option("--limit", type=int, help="Limit number of threads")
+@click.option(
+    "--limit",
+    type=int,
+    default=None,
+    show_default="unlimited",
+    help="Limit number of threads",
+)
 @click.option("--delay", type=float, default=1.0, show_default=True, help="Delay between requests in seconds")
 @click.option("--user-agent", default=None, help="Custom User-Agent string")
 @click.option("--max-retries", type=int, default=3, show_default=True, help="Max retries on request failures")


### PR DESCRIPTION
## Summary
- clarify `--limit` option by setting default `None` and show `unlimited` in CLI help
- mention that omitting `--limit` fetches all threads

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68420d23a6fc83259a8132e0e8ea60dc