### PR TITLE
Fix ds6 parsing when multiple blocks are present

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -45,10 +45,12 @@ class ThreadData:
 
 
 def _extract_ds6(html: str) -> list:
-    match = DS6_RE.search(html)
-    if not match:
+    matches = DS6_RE.findall(html)
+    if not matches:
         raise ValueError("ds:6 block not found")
-    return json.loads(match.group(1))
+    # Some pages include multiple ds:6 blocks. The last block usually
+    # contains the most complete data, so return that one.
+    return json.loads(matches[-1])
 
 
 def parse_thread_list(html: str) -> tuple[list[str], str | None]:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,6 +8,14 @@ def test_extract_ds6():
     assert _extract_ds6(html) == [["x"]]
 
 
+def test_extract_ds6_multiple_blocks():
+    html = (
+        "<script>AF_initDataCallback({key: 'ds:6', isError: false, data:[[\"x\"]], sideChannel:{}});</script>"
+        "<script>AF_initDataCallback({key: 'ds:6', isError: false, data:[[\"y\"]], sideChannel:{}});</script>"
+    )
+    assert _extract_ds6(html) == [["y"]]
+
+
 def test_parse_thread_list_token():
     html = (
         "<script>AF_initDataCallback({key: 'ds:6', isError: false, "


### PR DESCRIPTION
## Summary
- fix `_extract_ds6` to use the last ds:6 block
- test parsing when multiple ds:6 blocks exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68434cd7eedc8325902fea4db93cefc8