### PR TITLE
Fix MBOX envelope From line generation

### DIFF
--- a/formatter.py
+++ b/formatter.py
@@ -15,12 +15,15 @@ from parser import MessageData, ThreadData
 def _make_msg(message: MessageData, group_email: str, text_format: str) -> mailbox.mboxMessage:
     msg = mailbox.mboxMessage()
     ts = message.timestamp
-    timestamp = time.strftime("%a, %d %b %Y %H:%M:%S +0000", time.gmtime(ts))
-    msg.set_unixfrom(f"From {message.sender} {timestamp}")
+    ts_struct = time.gmtime(ts)
+    rfc822_ts = time.strftime("%a, %d %b %Y %H:%M:%S +0000", ts_struct)
+    # Set both the envelope "From " line and standard Date header
+    msg.set_from(message.sender, ts_struct)
+    msg.set_unixfrom(f"From {message.sender} {time.asctime(ts_struct)}")
     msg["From"] = message.sender
     msg["To"] = group_email
     msg["Subject"] = message.subject
-    msg["Date"] = timestamp
+    msg["Date"] = rfc822_ts
     msg["Message-ID"] = f"<{message.message_id}@scraped.local>"
     if message.parent_id:
         msg["In-Reply-To"] = f"<{message.parent_id}@scraped.local>"

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,8 +1,9 @@
 import os, sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from formatter import _make_msg
+from formatter import _make_msg, write_mbox
 from parser import MessageData, ThreadData
+import time
 
 
 def test_make_msg_plaintext():
@@ -20,4 +21,36 @@ def test_make_msg_plaintext():
     out = msg.as_string()
     assert "SGVsbG8" not in out
     assert "Hello" in out
+
+
+def test_from_line_contains_sender_and_timestamp(tmp_path):
+    ts1 = 0
+    ts2 = 60
+    threads = [
+        ThreadData(
+            thread_id="t",
+            subject="sub",
+            messages=[
+                MessageData(
+                    message_id="1",
+                    sender="alice@example.com",
+                    timestamp=ts1,
+                    subject="s1",
+                    body_html="<p>a</p>",
+                ),
+                MessageData(
+                    message_id="2",
+                    sender="bob@example.com",
+                    timestamp=ts2,
+                    subject="s2",
+                    body_html="<p>b</p>",
+                ),
+            ],
+        )
+    ]
+    out_file = tmp_path / "out.mbox"
+    write_mbox(threads, out_file, group_email="group@example.com", text_format="plaintext")
+    data = out_file.read_text()
+    assert f"From alice@example.com {time.asctime(time.gmtime(ts1))}" in data
+    assert f"From bob@example.com {time.asctime(time.gmtime(ts2))}" in data
 


### PR DESCRIPTION
## Summary
- ensure `_make_msg` writes the proper envelope `From` line
- test that mbox files contain the sender and timestamp in the envelope line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684353c2c62483258e27021fbf9704eb