### PR TITLE
Increase test coverage for parsing and utils

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+    branches: [main, work]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install uv
+        run: pip install uv
+      - name: Run tests
+        run: uv run --with-requirements=requirements.txt pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /__pycache__/
 /__pycache__/
+tests/__pycache__/

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ Run the unit tests without modifying your environment using
 uv run --with-requirements=requirements.txt pytest
 ```
 
+Tests run automatically on every push via the GitHub Actions workflow in
+`.github/workflows/tests.yml`.
+
 Alternatively, install the dependencies and run `pytest` directly:
 
 ```bash

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,3 +80,10 @@ def test_load_wait_option(monkeypatch, tmp_path):
     result = runner.invoke(cli.cli, ["http://example.com", "--load-wait", "0.5", "--output", str(out_file)])
     assert result.exit_code == 0
     assert configs and abs(configs[0].load_wait - 0.5) < 1e-6
+
+
+def test_make_full_url_cases():
+    base = "https://groups.google.com/g/test"
+    assert cli.make_full_url(base, "c/topic") == "https://groups.google.com/g/test/c/topic"
+    assert cli.make_full_url(base, "/forum/123") == "https://groups.google.com/forum/123"
+    assert cli.make_full_url(base, "https://example.com/x") == "https://example.com/x"

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -1,0 +1,28 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import fetcher
+import requests
+
+
+def test_fetch_requests_retries(monkeypatch):
+    calls = []
+
+    class DummyExc(requests.RequestException):
+        pass
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append(url)
+        if len(calls) == 1:
+            raise DummyExc("fail")
+        class Resp:
+            text = "ok"
+            def raise_for_status(self):
+                pass
+        return Resp()
+
+    monkeypatch.setattr(fetcher.requests, "get", fake_get)
+    monkeypatch.setattr(fetcher.time, "sleep", lambda x: None)
+    f = fetcher.Fetcher(fetcher.FetcherConfig(max_retries=2, delay=0))
+    assert f.fetch_requests("http://example.com") == "ok"
+    assert len(calls) == 2

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -54,3 +54,18 @@ def test_from_line_contains_sender_and_timestamp(tmp_path):
     assert f"From alice@example.com {time.asctime(time.gmtime(ts1))}" in data
     assert f"From bob@example.com {time.asctime(time.gmtime(ts2))}" in data
 
+
+def test_make_msg_markdown_content_type():
+    msg = _make_msg(
+        MessageData(
+            message_id="1",
+            sender="a@example.com",
+            timestamp=0,
+            subject="sub",
+            body_html="<b>Hello</b>",
+        ),
+        group_email="group@example.com",
+        text_format="markdown",
+    )
+    assert msg["Content-Type"].startswith("text/plain")
+    assert "**Hello**" in msg.get_payload(decode=True).decode()

--- a/tests/test_parse_thread.py
+++ b/tests/test_parse_thread.py
@@ -1,0 +1,28 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import json
+from parser import parse_thread
+
+
+def build_html(data):
+    json_data = json.dumps(data)
+    return (
+        "<script>AF_initDataCallback({key: 'ds:6', isError: false, "
+        "data:" + json_data + ", sideChannel:{}});</script>"
+    )
+
+
+def test_parse_thread_basic():
+    head1 = [0, "t1", [["alice@example.com"]], None, None, "Subject1", None, [0]]
+    body1 = [None, [[None, [None, "<p>m1</p>"]]]]
+    head2 = [0, "m2", [["bob@example.com"]], None, None, "Subject2", None, [60]]
+    body2 = [None, [[None, [None, "<p>m2</p>"]]]]
+    data = [None, None, [[[head1, body1, head2, body2]]]]
+    html = build_html(data)
+    thread = parse_thread(html)
+    assert thread.thread_id == "t1"
+    assert thread.subject == "Subject1"
+    assert len(thread.messages) == 2
+    assert thread.messages[1].subject == "Subject2"
+    assert thread.messages[1].body_html == "<p>m2</p>"


### PR DESCRIPTION
## Summary
- add tests for CLI URL building
- add retry logic test for fetcher
- cover parse_thread message extraction
- verify markdown conversion in formatter
- document running tests and set up CI workflow

## Testing
- `uv run --with-requirements=requirements.txt pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684362e839288325b1e70eafe171ba5f